### PR TITLE
Avoid cyclic reloads by overwriting with the same contents

### DIFF
--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -16,8 +16,17 @@ module.exports = function($projectData) {
   const config = path.join(appPath, 'release-info.json');
 
   return new Promise((resolve, reject) => {
+    var contents = JSON.stringify(options, null, 2);
+    
+    // Don't overwrite file with the same options not to trigger the cyclic reload
+    if (fs.existsSync(config) &&
+        fs.readFileSync(config, "utf8") === contents) {
 
-    fs.writeFile(config, JSON.stringify(options, null, 2), err => {
+      resolve(config);
+      return;
+    }
+    
+    fs.writeFile(config, contents, err => {
 
       if (err) {
         return reject(err);


### PR DESCRIPTION
When changing any file this pre-hook overwrites the release info file which triggers another reload and another... until it finally races away and stops reloading. This patch avoids overwriting file with the same contents and thus not triggering the reload.